### PR TITLE
Make getServerSideProps return props serializable

### DIFF
--- a/lib/displayHelpers.js
+++ b/lib/displayHelpers.js
@@ -25,6 +25,8 @@ const thinSpace = "\u202F";
 // A leading "u" is interpreted as µ (micro) and uxyz will be converted to XYZ
 // for displaying.
 const printableCoin = (coin) => {
+  if (!coin) return "–";
+
   if (coin.denom?.startsWith("u")) {
     const ticker = coin.denom.slice(1).toUpperCase();
     return Decimal.fromAtomics(coin.amount ?? "0", 6).toString() + thinSpace + ticker;

--- a/pages/multi/[address]/index.js
+++ b/pages/multi/[address]/index.js
@@ -13,25 +13,23 @@ import TransactionForm from "../../../components/forms/TransactionForm";
 import TransactionList from "../../../components/dataViews/TransactionList";
 
 export async function getServerSideProps(context) {
-  let holdings;
   try {
     const client = await StargateClient.connect(
       process.env.NEXT_PUBLIC_NODE_ADDRESS
     );
     const multisigAddress = context.params.address;
-    holdings = await client.getBalance(
+    const holdings = await client.getBalance(
       multisigAddress,
       process.env.NEXT_PUBLIC_DENOM
     );
     const accountOnChain = await getMultisigAccount(multisigAddress, client);
-
     return {
-      props: { accountOnChain, holdings: holdings },
+      props: { accountOnChain, holdings },
     };
   } catch (error) {
     console.log(error);
     return {
-      props: { error: error.message, holdings: holdings },
+      props: { error: error.message },
     };
   }
 }


### PR DESCRIPTION
In the error case, `holdings` is undefined. However, `undefined` values are not considered seralizable by next.js:

<img width="782" alt="Bildschirmfoto 2022-01-11 um 10 52 26" src="https://user-images.githubusercontent.com/2603011/148924120-360ff8ac-e6c8-4f7b-bcd3-d6cf41afe79a.png">

Turns out the [documentation of getServerSideProps](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering) also says

> props - An optional object with the props that will be received by the page component. It should be a serializable object or a Promise that resolves to a serializable object.

Next.js has a stricter definition of what is serializable than the default JSON serializer, where you can do

```
> JSON.stringify({ foo: 123, bar: undefined })
'{"foo":123}'
```

With this PR, the property is simply not set (just like accountOnChain) and produces the same `undefined` value when deserialized.